### PR TITLE
Add minimal FastAPI intake service with Nextcloud ping and QR code

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+NC_BASE_URL=https://nextcloud.example
+NC_USER=your-user
+NC_APP_PASSWORD=your-app-password

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.env
+__pycache__/
+uploads/*
+!uploads/.gitkeep

--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
-# GRB
+# GRB Intake Prototype
+
+Dieses Projekt stellt einen minimalen Intake-Mechanismus bereit. Bilder können über ein Webformular hochgeladen werden, eine Testanfrage an eine Nextcloud-Instanz wird unterstützt und aus beliebigem Text lässt sich ein QR-Code generieren.
+
+## Setup
+
+1. Installiere die benötigten Abhängigkeiten (Podman, podman-compose, Python‑Pakete):
+
+   ```bash
+   ./install.sh
+   ```
+
+2. Kopiere `.env.example` nach `.env` und trage `NC_BASE_URL`, `NC_USER` und `NC_APP_PASSWORD` deiner Nextcloud ein.
+3. Starte die Anwendung mit Podman:
+
+   ```bash
+   podman-compose -f podman-compose.yml up
+   ```
+
+4. Rufe im Browser `http://localhost:8000` auf.
+
+## Funktionsweise
+
+- **Upload**: Mehrere Bilder werden lokal im Verzeichnis `uploads/` gespeichert.
+- **Nextcloud-Test**: Der Button „Test Nextcloud“ sendet einen Ping an `/nc/ping` und zeigt die Antwort der OCS-API.
+- **QR-Code**: Der Button „QR generieren“ ruft `/qr?text=...` auf und zeigt den generierten Code.
+
+## Tests
+
+- Die Anwendung lässt sich mit `python -m py_compile app/main.py` auf Syntax prüfen.
+- Manuelle Tests erfolgen über die Weboberfläche.

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,54 @@
+import io
+import os
+from pathlib import Path
+from typing import List
+
+import httpx
+import segno
+from fastapi import FastAPI, File, UploadFile
+from fastapi.responses import FileResponse, JSONResponse, Response
+from fastapi.staticfiles import StaticFiles
+
+app = FastAPI()
+
+app.mount("/static", StaticFiles(directory="static"), name="static")
+
+
+@app.get("/")
+async def read_index():
+    return FileResponse("static/index.html")
+
+
+@app.post("/intake")
+async def intake(files: List[UploadFile] = File(...)):
+    upload_dir = Path("uploads")
+    upload_dir.mkdir(parents=True, exist_ok=True)
+    saved = []
+    for file in files:
+        dest = upload_dir / file.filename
+        with open(dest, "wb") as f:
+            f.write(await file.read())
+        saved.append({"filename": file.filename, "path": str(dest)})
+    return {"files": saved}
+
+
+@app.get("/nc/ping")
+async def nc_ping():
+    base_url = os.getenv("NC_BASE_URL")
+    user = os.getenv("NC_USER")
+    password = os.getenv("NC_APP_PASSWORD")
+    if not base_url or not user or not password:
+        return JSONResponse(status_code=500, content={"error": "Nextcloud credentials missing"})
+    url = base_url.rstrip("/") + "/ocs/v1.php/cloud/capabilities"
+    headers = {"OCS-APIRequest": "true"}
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(url, auth=(user, password), headers=headers)
+    return JSONResponse(status_code=resp.status_code, content=resp.json())
+
+
+@app.get("/qr")
+async def generate_qr(text: str):
+    qr = segno.make(text)
+    buf = io.BytesIO()
+    qr.save(buf, kind="png")
+    return Response(content=buf.getvalue(), media_type="image/png")

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install Podman if not present
+if ! command -v podman >/dev/null 2>&1; then
+  echo "Installing podman..."
+  if command -v apt-get >/dev/null 2>&1; then
+    sudo apt-get update
+    sudo apt-get install -y podman
+  else
+    echo "apt-get not found. Please install podman manually." >&2
+    exit 1
+  fi
+fi
+
+# Install podman-compose if not present
+if ! command -v podman-compose >/dev/null 2>&1; then
+  echo "Installing podman-compose..."
+  if command -v pip >/dev/null 2>&1; then
+    pip install --user podman-compose
+    export PATH="$PATH:$HOME/.local/bin"
+  else
+    echo "pip not found. Installing python3-pip..."
+    if command -v apt-get >/dev/null 2>&1; then
+      sudo apt-get install -y python3-pip
+      pip install --user podman-compose
+      export PATH="$PATH:$HOME/.local/bin"
+    else
+      echo "Neither pip nor apt-get available to install podman-compose" >&2
+      exit 1
+    fi
+  fi
+fi
+
+# Install Python dependencies
+if [ -f requirements.txt ]; then
+  echo "Installing Python dependencies from requirements.txt..."
+  pip install -r requirements.txt
+fi
+
+echo "Installation finished."

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -1,0 +1,11 @@
+services:
+  api:
+    image: python:3.11-slim
+    working_dir: /app
+    volumes:
+      - .:/app
+    env_file:
+      - .env
+    command: bash -c "pip install fastapi uvicorn[standard] segno httpx && uvicorn app.main:app --host 0.0.0.0 --port 8000"
+    ports:
+      - "8000:8000"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn[standard]
+segno
+httpx

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8" />
+  <title>Intake</title>
+</head>
+<body>
+  <h1>Intake</h1>
+  <form id="upload-form" enctype="multipart/form-data">
+    <input type="file" name="files" multiple />
+    <button type="submit">Upload</button>
+  </form>
+
+  <button id="nc-test">Test Nextcloud</button>
+  <pre id="nc-result"></pre>
+
+  <input id="qr-text" type="text" placeholder="QR Text" />
+  <button id="qr-gen">QR generieren</button>
+  <br />
+  <img id="qr-img" alt="QR" />
+
+  <script>
+    const uploadForm = document.getElementById('upload-form');
+    uploadForm.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const data = new FormData(uploadForm);
+      const res = await fetch('/intake', { method: 'POST', body: data });
+      alert(JSON.stringify(await res.json()));
+    });
+
+    document.getElementById('nc-test').addEventListener('click', async () => {
+      const res = await fetch('/nc/ping');
+      const txt = await res.text();
+      document.getElementById('nc-result').textContent = txt;
+    });
+
+    document.getElementById('qr-gen').addEventListener('click', () => {
+      const text = encodeURIComponent(document.getElementById('qr-text').value);
+      document.getElementById('qr-img').src = '/qr?text=' + text;
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- scaffold FastAPI backend with endpoints for file intake, Nextcloud ping and QR generation
- add simple web form for uploads, ping trigger and QR display
- document podman-compose setup and environment variables
- add installation script to set up Podman, podman-compose and Python requirements

## Testing
- `python -m py_compile app/main.py`
- `bash -n install.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a62270b544832d9e2d81f19f657049