### PR TITLE
Transform flow field into boid simulation

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,14 +11,14 @@
     <header class="hero">
       <div class="headline">
         <p class="eyebrow">GRB · Procedural Animation Sandbox</p>
-        <h1>Flow fields for playful tinkering</h1>
+        <h1>Boids flocking in a minimal sandbox</h1>
         <p class="lede">
-          A minimal canvas playground that paints particle trails through a shifting flow field.
-          Use it as a starting point for animation experiments and simulations.
+          A canvas playground where simple rules create emergent flocking. Adjust the sliders to
+          steer alignment, cohesion, separation, and speed in real time.
         </p>
       </div>
       <div class="controls" aria-live="polite">
-        <p>Particles continuously move with a noise-driven velocity field. Refresh to regenerate.</p>
+        <div class="controls__grid" data-control-panel></div>
       </div>
     </header>
     <section class="canvas-panel">

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -2,18 +2,32 @@ const canvas = document.getElementById('flow-canvas');
 const ctx = canvas.getContext('2d', { alpha: true });
 
 const state = {
-  particles: [],
+  boids: [],
   settings: {
-    particleCount: 650,
-    speed: 0.6,
-    curl: 0.0025,
+    boidCount: 420,
+    maxSpeed: 2.4,
+    maxForce: 0.04,
+    perception: 72,
+    separationWeight: 1.4,
+    alignmentWeight: 1.0,
+    cohesionWeight: 0.8,
     trail: 0.08,
   },
   frame: 0,
 };
 
+const controlDefinitions = [
+  { key: 'boidCount', label: 'Boid count', min: 150, max: 900, step: 10, format: (v) => Math.round(v) },
+  { key: 'maxSpeed', label: 'Max speed', min: 0.6, max: 4, step: 0.1, format: (v) => v.toFixed(1) },
+  { key: 'maxForce', label: 'Steering force', min: 0.005, max: 0.12, step: 0.005, format: (v) => v.toFixed(3) },
+  { key: 'perception', label: 'Perception radius', min: 24, max: 140, step: 2, format: (v) => Math.round(v) },
+  { key: 'separationWeight', label: 'Separation', min: 0.5, max: 2.5, step: 0.1, format: (v) => v.toFixed(1) },
+  { key: 'alignmentWeight', label: 'Alignment', min: 0.4, max: 2.2, step: 0.1, format: (v) => v.toFixed(1) },
+  { key: 'cohesionWeight', label: 'Cohesion', min: 0.4, max: 2.2, step: 0.1, format: (v) => v.toFixed(1) },
+];
+
 const log = (message, extra = {}) => {
-  console.info(`[flow-field] ${message}`, extra);
+  console.info(`[boids] ${message}`, extra);
 };
 
 function resizeCanvas() {
@@ -22,53 +36,216 @@ function resizeCanvas() {
   canvas.height = parent.clientHeight * devicePixelRatio;
   ctx.setTransform(1, 0, 0, 1, 0, 0);
   ctx.scale(devicePixelRatio, devicePixelRatio);
-  ctx.lineWidth = 1;
+  ctx.lineWidth = 1.2;
   log('Canvas resized', { width: canvas.width, height: canvas.height });
 }
 
-function createParticles() {
-  state.particles = Array.from({ length: state.settings.particleCount }, () => ({
+function seedBoids() {
+  state.boids = Array.from({ length: state.settings.boidCount }, () => ({
     x: Math.random() * canvas.clientWidth,
     y: Math.random() * canvas.clientHeight,
+    vx: (Math.random() - 0.5) * state.settings.maxSpeed,
+    vy: (Math.random() - 0.5) * state.settings.maxSpeed,
   }));
-  log('Particles seeded', { count: state.particles.length });
+  log('Boids seeded', { count: state.boids.length });
 }
 
-function pseudoCurlNoise(x, y, time) {
-  // Smooth swirling field built from sine waves; deterministic for reproducibility.
-  const scale = state.settings.curl;
-  const n = Math.sin((x + time) * scale) + Math.cos((y - time) * scale * 1.3);
-  const m = Math.cos((y + time) * scale * 0.9) - Math.sin((x - time) * scale * 1.1);
-  return Math.atan2(n, m);
+function adjustBoidCount(nextCount) {
+  const current = state.boids.length;
+  if (nextCount === current) return;
+
+  if (nextCount > current) {
+    const toAdd = nextCount - current;
+    const additions = Array.from({ length: toAdd }, () => ({
+      x: Math.random() * canvas.clientWidth,
+      y: Math.random() * canvas.clientHeight,
+      vx: (Math.random() - 0.5) * state.settings.maxSpeed,
+      vy: (Math.random() - 0.5) * state.settings.maxSpeed,
+    }));
+    state.boids.push(...additions);
+  } else {
+    state.boids.length = nextCount;
+  }
+  log('Boid count adjusted', { count: state.boids.length });
+}
+
+function limitVector(x, y, max) {
+  const mag = Math.hypot(x, y);
+  if (mag > max) {
+    const scale = max / mag;
+    return { x: x * scale, y: y * scale };
+  }
+  return { x, y };
+}
+
+function steerBoid(boid, index) {
+  const {
+    perception,
+    separationWeight,
+    alignmentWeight,
+    cohesionWeight,
+    maxSpeed,
+    maxForce,
+  } = state.settings;
+
+  let total = 0;
+  let steerSeparation = { x: 0, y: 0 };
+  let steerAlignment = { x: 0, y: 0 };
+  let steerCohesion = { x: 0, y: 0 };
+
+  state.boids.forEach((other, i) => {
+    if (i === index) return;
+    const dx = other.x - boid.x;
+    const dy = other.y - boid.y;
+    const dist = Math.hypot(dx, dy);
+    if (dist > 0 && dist < perception) {
+      const invDist = 1 / dist;
+      steerSeparation.x -= dx * invDist;
+      steerSeparation.y -= dy * invDist;
+
+      steerAlignment.x += other.vx;
+      steerAlignment.y += other.vy;
+
+      steerCohesion.x += other.x;
+      steerCohesion.y += other.y;
+      total += 1;
+    }
+  });
+
+  if (total > 0) {
+    steerSeparation = limitVector(steerSeparation.x / total, steerSeparation.y / total, maxForce);
+
+    steerAlignment = limitVector(
+      steerAlignment.x / total - boid.vx,
+      steerAlignment.y / total - boid.vy,
+      maxForce,
+    );
+
+    steerCohesion = limitVector(
+      steerCohesion.x / total - boid.x,
+      steerCohesion.y / total - boid.y,
+      maxForce,
+    );
+  }
+
+  const ax =
+    steerSeparation.x * separationWeight +
+    steerAlignment.x * alignmentWeight +
+    steerCohesion.x * cohesionWeight;
+  const ay =
+    steerSeparation.y * separationWeight +
+    steerAlignment.y * alignmentWeight +
+    steerCohesion.y * cohesionWeight;
+
+  const limited = limitVector(ax, ay, maxForce);
+  return limited;
+}
+
+function drawBoid(x, y, angle) {
+  const size = 6;
+  ctx.save();
+  ctx.translate(x, y);
+  ctx.rotate(angle);
+  ctx.beginPath();
+  ctx.moveTo(size, 0);
+  ctx.lineTo(-size * 0.8, size * 0.6);
+  ctx.lineTo(-size * 0.8, -size * 0.6);
+  ctx.closePath();
+  ctx.stroke();
+  ctx.restore();
 }
 
 function step() {
-  const { speed, trail } = state.settings;
-  const w = canvas.clientWidth;
-  const h = canvas.clientHeight;
-  state.frame += 1;
+  try {
+    const { maxSpeed, trail } = state.settings;
+    const w = canvas.clientWidth;
+    const h = canvas.clientHeight;
+    state.frame += 1;
 
-  ctx.fillStyle = `rgba(10, 13, 18, ${trail})`;
-  ctx.fillRect(0, 0, w, h);
-  ctx.strokeStyle = 'rgba(110, 199, 255, 0.8)';
+    ctx.fillStyle = `rgba(10, 13, 18, ${trail})`;
+    ctx.fillRect(0, 0, w, h);
+    ctx.strokeStyle = 'rgba(110, 199, 255, 0.86)';
 
-  ctx.beginPath();
-  state.particles.forEach((p) => {
-    const angle = pseudoCurlNoise(p.x, p.y, state.frame);
-    p.x += Math.cos(angle) * speed;
-    p.y += Math.sin(angle) * speed;
+    state.boids.forEach((boid, index) => {
+      const { x, y } = boid;
+      const { x: ax, y: ay } = steerBoid(boid, index);
 
-    if (p.x < 0) p.x = w;
-    else if (p.x > w) p.x = 0;
-    if (p.y < 0) p.y = h;
-    else if (p.y > h) p.y = 0;
+      boid.vx += ax;
+      boid.vy += ay;
 
-    ctx.moveTo(p.x, p.y);
-    ctx.lineTo(p.x + 0.1, p.y + 0.1);
-  });
-  ctx.stroke();
+      const limited = limitVector(boid.vx, boid.vy, maxSpeed);
+      boid.vx = limited.x;
+      boid.vy = limited.y;
+
+      boid.x += boid.vx;
+      boid.y += boid.vy;
+
+      if (boid.x < 0) boid.x = w;
+      else if (boid.x > w) boid.x = 0;
+      if (boid.y < 0) boid.y = h;
+      else if (boid.y > h) boid.y = 0;
+
+      const angle = Math.atan2(boid.vy, boid.vx);
+      drawBoid(boid.x, boid.y, angle);
+    });
+  } catch (error) {
+    console.error('[boids] Animation step failed', error);
+  }
 
   requestAnimationFrame(step);
+}
+
+function handleControlChange(event) {
+  const { name, value } = event.target;
+  const parsed = parseFloat(value);
+  if (Number.isNaN(parsed)) return;
+
+  state.settings[name] = parsed;
+  if (name === 'boidCount') {
+    adjustBoidCount(Math.round(parsed));
+  }
+
+  const display = document.querySelector(`[data-display="${name}"]`);
+  const definition = controlDefinitions.find((c) => c.key === name);
+  if (display && definition) {
+    display.textContent = definition.format(parsed);
+  }
+  log('Control updated', { [name]: parsed });
+}
+
+function renderControls() {
+  const container = document.querySelector('[data-control-panel]');
+  if (!container) return;
+
+  const fragment = document.createDocumentFragment();
+  controlDefinitions.forEach((control) => {
+    const wrapper = document.createElement('label');
+    wrapper.className = 'slider';
+    wrapper.innerHTML = `
+      <div class="slider__header">
+        <span>${control.label}</span>
+        <span class="slider__value" data-display="${control.key}">${control.format(
+      state.settings[control.key],
+    )}</span>
+      </div>
+      <input
+        type="range"
+        name="${control.key}"
+        min="${control.min}"
+        max="${control.max}"
+        step="${control.step}"
+        value="${state.settings[control.key]}"
+        aria-label="${control.label}"
+      />
+    `;
+    const input = wrapper.querySelector('input');
+    input.addEventListener('input', handleControlChange);
+    fragment.appendChild(wrapper);
+  });
+
+  container.innerHTML = '';
+  container.appendChild(fragment);
+  log('Controls rendered');
 }
 
 function start() {
@@ -77,14 +254,15 @@ function start() {
       throw new Error('2D context unavailable');
     }
     resizeCanvas();
-    createParticles();
+    seedBoids();
+    renderControls();
     ctx.fillStyle = 'rgba(10, 13, 18, 1)';
     ctx.fillRect(0, 0, canvas.clientWidth, canvas.clientHeight);
     requestAnimationFrame(step);
     window.addEventListener('resize', resizeCanvas);
-    log('Flow field animation started');
+    log('Boid simulation started');
   } catch (error) {
-    console.error('[flow-field] Failed to start animation', error);
+    console.error('[boids] Failed to start simulation', error);
   }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -68,6 +68,42 @@ main.layout {
   color: var(--muted);
 }
 
+.controls__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+  margin-top: 18px;
+}
+
+.slider {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 10px;
+}
+
+.slider__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  color: var(--text);
+  font-size: 14px;
+}
+
+.slider__value {
+  color: var(--accent);
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+}
+
+.slider input[type='range'] {
+  width: 100%;
+  accent-color: var(--accent);
+}
+
 .canvas-panel {
   background: var(--panel);
   border: 1px solid rgba(255, 255, 255, 0.06);


### PR DESCRIPTION
## Summary
- replace the original flow-field particle sketch with a boid-based flocking simulation
- add interactive slider controls for flock parameters like count, speed, force, and radii
- refresh page copy and styling to accommodate the new control panel

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b4e2b14bc832d9b6705b2ec8d0f33)