### PR TITLE
Evolve boid behaviors and visualize genome colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,8 +13,8 @@
         <p class="eyebrow">GRB · Procedural Animation Sandbox</p>
         <h1>Boids flocking in a minimal sandbox</h1>
         <p class="lede">
-          A canvas playground where simple rules create emergent flocking. Adjust the sliders to
-          steer alignment, cohesion, separation, and speed in real time.
+          A canvas playground where simple rules create emergent flocking. Watch traits evolve
+          automatically as boids seek food, avoid hazards, and adapt over generations.
         </p>
       </div>
       <div class="controls" aria-live="polite">

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,30 +1,35 @@
 const canvas = document.getElementById('flow-canvas');
 const ctx = canvas.getContext('2d', { alpha: true });
 
+const genomeRanges = {
+  perception: { min: 28, max: 140 },
+  separationWeight: { min: 0.6, max: 2.5 },
+  alignmentWeight: { min: 0.5, max: 2.2 },
+  cohesionWeight: { min: 0.5, max: 2.2 },
+  maxSpeed: { min: 0.8, max: 3.6 },
+  maxForce: { min: 0.01, max: 0.08 },
+};
+
 const state = {
   boids: [],
+  foods: [],
+  bestPerformer: null,
   settings: {
     boidCount: 420,
-    maxSpeed: 2.4,
-    maxForce: 0.04,
-    perception: 72,
-    separationWeight: 1.4,
-    alignmentWeight: 1.0,
-    cohesionWeight: 0.8,
     trail: 0.08,
+    foodCount: 36,
+    foodDecayRate: 0.002,
+    foodReward: 1.2,
+    foodDepletionOnEat: 0.5,
+    starvationRate: 0.003,
+    initialEnergy: 1.0,
+    minNeighborsForSafety: 2,
+    lonelyDeathChance: 0.008,
+    mutationRate: 0.26,
+    mutationScale: 0.18,
   },
   frame: 0,
 };
-
-const controlDefinitions = [
-  { key: 'boidCount', label: 'Boid count', min: 150, max: 900, step: 10, format: (v) => Math.round(v) },
-  { key: 'maxSpeed', label: 'Max speed', min: 0.6, max: 4, step: 0.1, format: (v) => v.toFixed(1) },
-  { key: 'maxForce', label: 'Steering force', min: 0.005, max: 0.12, step: 0.005, format: (v) => v.toFixed(3) },
-  { key: 'perception', label: 'Perception radius', min: 24, max: 140, step: 2, format: (v) => Math.round(v) },
-  { key: 'separationWeight', label: 'Separation', min: 0.5, max: 2.5, step: 0.1, format: (v) => v.toFixed(1) },
-  { key: 'alignmentWeight', label: 'Alignment', min: 0.4, max: 2.2, step: 0.1, format: (v) => v.toFixed(1) },
-  { key: 'cohesionWeight', label: 'Cohesion', min: 0.4, max: 2.2, step: 0.1, format: (v) => v.toFixed(1) },
-];
 
 const log = (message, extra = {}) => {
   console.info(`[boids] ${message}`, extra);
@@ -40,13 +45,58 @@ function resizeCanvas() {
   log('Canvas resized', { width: canvas.width, height: canvas.height });
 }
 
-function seedBoids() {
-  state.boids = Array.from({ length: state.settings.boidCount }, () => ({
+function normalized(value, min, max) {
+  return (value - min) / (max - min);
+}
+
+function randomGenome() {
+  return Object.fromEntries(
+    Object.entries(genomeRanges).map(([key, range]) => [key, range.min + Math.random() * (range.max - range.min)]),
+  );
+}
+
+function mutateGenome(baseGenome) {
+  const { mutationRate, mutationScale } = state.settings;
+  return Object.fromEntries(
+    Object.entries(genomeRanges).map(([key, range]) => {
+      const original = baseGenome[key];
+      const shouldMutate = Math.random() < mutationRate;
+      const magnitude = shouldMutate ? 1 + (Math.random() * 2 - 1) * mutationScale : 1;
+      const mutated = original * magnitude;
+      const clamped = Math.min(range.max, Math.max(range.min, mutated));
+      return [key, clamped];
+    }),
+  );
+}
+
+function deriveBoidColor(genome) {
+  const r = Math.floor(normalized(genome.separationWeight, genomeRanges.separationWeight.min, genomeRanges.separationWeight.max) * 255);
+  const g = Math.floor(normalized(genome.cohesionWeight, genomeRanges.cohesionWeight.min, genomeRanges.cohesionWeight.max) * 255);
+  const b = Math.floor(normalized(genome.alignmentWeight, genomeRanges.alignmentWeight.min, genomeRanges.alignmentWeight.max) * 255);
+  return `rgba(${r}, ${g}, ${b}, 0.9)`;
+}
+
+function createBoid(base = {}) {
+  const { initialEnergy } = state.settings;
+  const genome = base.genome ?? randomGenome();
+  const nextVx = base.vx ?? (Math.random() - 0.5) * genome.maxSpeed;
+  const nextVy = base.vy ?? (Math.random() - 0.5) * genome.maxSpeed;
+  const limited = limitVector(nextVx, nextVy, genome.maxSpeed);
+  return {
     x: Math.random() * canvas.clientWidth,
     y: Math.random() * canvas.clientHeight,
-    vx: (Math.random() - 0.5) * state.settings.maxSpeed,
-    vy: (Math.random() - 0.5) * state.settings.maxSpeed,
-  }));
+    vx: limited.x,
+    vy: limited.y,
+    energy: initialEnergy,
+    score: 0,
+    lastNeighborCount: 0,
+    genome,
+    color: deriveBoidColor(genome),
+  };
+}
+
+function seedBoids() {
+  state.boids = Array.from({ length: state.settings.boidCount }, () => createBoid());
   log('Boids seeded', { count: state.boids.length });
 }
 
@@ -56,12 +106,7 @@ function adjustBoidCount(nextCount) {
 
   if (nextCount > current) {
     const toAdd = nextCount - current;
-    const additions = Array.from({ length: toAdd }, () => ({
-      x: Math.random() * canvas.clientWidth,
-      y: Math.random() * canvas.clientHeight,
-      vx: (Math.random() - 0.5) * state.settings.maxSpeed,
-      vy: (Math.random() - 0.5) * state.settings.maxSpeed,
-    }));
+    const additions = Array.from({ length: toAdd }, () => createBoid());
     state.boids.push(...additions);
   } else {
     state.boids.length = nextCount;
@@ -79,14 +124,8 @@ function limitVector(x, y, max) {
 }
 
 function steerBoid(boid, index) {
-  const {
-    perception,
-    separationWeight,
-    alignmentWeight,
-    cohesionWeight,
-    maxSpeed,
-    maxForce,
-  } = state.settings;
+  const { perception, separationWeight, alignmentWeight, cohesionWeight, maxForce } = boid.genome;
+  const { maxSpeed } = boid.genome;
 
   let total = 0;
   let steerSeparation = { x: 0, y: 0 };
@@ -138,15 +177,17 @@ function steerBoid(boid, index) {
     steerCohesion.y * cohesionWeight;
 
   const limited = limitVector(ax, ay, maxForce);
-  return limited;
+  return { ...limited, neighborCount: total };
 }
 
-function drawBoid(x, y, angle) {
+function drawBoid(boid) {
   const size = 6;
+  const angle = Math.atan2(boid.vy, boid.vx);
   ctx.save();
-  ctx.translate(x, y);
+  ctx.translate(boid.x, boid.y);
   ctx.rotate(angle);
   ctx.beginPath();
+  ctx.strokeStyle = boid.color;
   ctx.moveTo(size, 0);
   ctx.lineTo(-size * 0.8, size * 0.6);
   ctx.lineTo(-size * 0.8, -size * 0.6);
@@ -155,9 +196,107 @@ function drawBoid(x, y, angle) {
   ctx.restore();
 }
 
+function createFood() {
+  return {
+    x: Math.random() * canvas.clientWidth,
+    y: Math.random() * canvas.clientHeight,
+    value: 1,
+  };
+}
+
+function seedFood() {
+  state.foods = Array.from({ length: state.settings.foodCount }, () => createFood());
+  log('Food seeded', { count: state.foods.length });
+}
+
+function decayFood() {
+  const { foodDecayRate } = state.settings;
+  state.foods = state.foods.map((food) => {
+    const nextValue = Math.max(0, food.value - foodDecayRate);
+    if (nextValue === 0) {
+      return createFood();
+    }
+    return { ...food, value: nextValue };
+  });
+}
+
+function drawFood(food) {
+  const radius = 5 + food.value * 4;
+  ctx.save();
+  ctx.beginPath();
+  ctx.fillStyle = `rgba(120, 255, 140, ${0.2 + food.value * 0.6})`;
+  ctx.strokeStyle = 'rgba(70, 140, 90, 0.7)';
+  ctx.arc(food.x, food.y, radius, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.stroke();
+  ctx.restore();
+}
+
+function trackBestPerformer(boid) {
+  if (!state.bestPerformer || boid.score > state.bestPerformer.score) {
+    state.bestPerformer = { vx: boid.vx, vy: boid.vy, score: boid.score, genome: boid.genome };
+    log('Best performer updated', { score: boid.score.toFixed(2), genome: boid.genome });
+  }
+}
+
+function tryConsumeFood(boid) {
+  const { foodReward, foodDepletionOnEat } = state.settings;
+  let reward = 0;
+  state.foods = state.foods.map((food) => {
+    const dx = food.x - boid.x;
+    const dy = food.y - boid.y;
+    const dist = Math.hypot(dx, dy);
+    if (dist < 14 && food.value > 0.05) {
+      const bite = Math.min(food.value, foodDepletionOnEat);
+      reward += bite * foodReward;
+      const remaining = food.value - bite;
+      if (remaining <= 0.02) {
+        return createFood();
+      }
+      return { ...food, value: remaining };
+    }
+    return food;
+  });
+
+  if (reward > 0) {
+    boid.energy += reward;
+    boid.score += reward;
+    trackBestPerformer(boid);
+  }
+}
+
+function spawnFromBest() {
+  const baseGenome = state.bestPerformer?.genome ?? randomGenome();
+  const genome = mutateGenome(baseGenome);
+  const velocityJitter = (Math.random() - 0.5) * 0.5;
+  const boid = createBoid({
+    vx: (state.bestPerformer?.vx ?? (Math.random() - 0.5) * genome.maxSpeed) + velocityJitter,
+    vy: (state.bestPerformer?.vy ?? (Math.random() - 0.5) * genome.maxSpeed) - velocityJitter,
+    genome,
+  });
+  log('Boid spawned from best performer', { genome });
+  return boid;
+}
+
+function shouldBoidDie(boid) {
+  const { minNeighborsForSafety, lonelyDeathChance, starvationRate } = state.settings;
+  boid.energy -= starvationRate;
+  if (boid.energy <= 0) {
+    return true;
+  }
+
+  if (boid.lastNeighborCount < minNeighborsForSafety) {
+    const roll = Math.random();
+    if (roll < lonelyDeathChance) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function step() {
   try {
-    const { maxSpeed, trail } = state.settings;
+    const { trail } = state.settings;
     const w = canvas.clientWidth;
     const h = canvas.clientHeight;
     state.frame += 1;
@@ -166,14 +305,21 @@ function step() {
     ctx.fillRect(0, 0, w, h);
     ctx.strokeStyle = 'rgba(110, 199, 255, 0.86)';
 
-    state.boids.forEach((boid, index) => {
-      const { x, y } = boid;
-      const { x: ax, y: ay } = steerBoid(boid, index);
+    decayFood();
+    state.foods.forEach((food) => drawFood(food));
 
+    const nextBoids = [];
+
+    for (let index = 0; index < state.boids.length; index += 1) {
+      const boid = state.boids[index];
+      const { x, y } = boid;
+      const { x: ax, y: ay, neighborCount } = steerBoid(boid, index);
+
+      boid.lastNeighborCount = neighborCount;
       boid.vx += ax;
       boid.vy += ay;
 
-      const limited = limitVector(boid.vx, boid.vy, maxSpeed);
+      const limited = limitVector(boid.vx, boid.vy, boid.genome.maxSpeed);
       boid.vx = limited.x;
       boid.vy = limited.y;
 
@@ -185,9 +331,19 @@ function step() {
       if (boid.y < 0) boid.y = h;
       else if (boid.y > h) boid.y = 0;
 
-      const angle = Math.atan2(boid.vy, boid.vx);
-      drawBoid(boid.x, boid.y, angle);
-    });
+      tryConsumeFood(boid);
+
+      if (shouldBoidDie(boid)) {
+        log('Boid removed', { frame: state.frame, score: boid.score.toFixed(2) });
+        nextBoids.push(spawnFromBest());
+        continue;
+      }
+
+      drawBoid(boid);
+      nextBoids.push(boid);
+    }
+
+    state.boids = nextBoids;
   } catch (error) {
     console.error('[boids] Animation step failed', error);
   }
@@ -195,57 +351,12 @@ function step() {
   requestAnimationFrame(step);
 }
 
-function handleControlChange(event) {
-  const { name, value } = event.target;
-  const parsed = parseFloat(value);
-  if (Number.isNaN(parsed)) return;
-
-  state.settings[name] = parsed;
-  if (name === 'boidCount') {
-    adjustBoidCount(Math.round(parsed));
-  }
-
-  const display = document.querySelector(`[data-display="${name}"]`);
-  const definition = controlDefinitions.find((c) => c.key === name);
-  if (display && definition) {
-    display.textContent = definition.format(parsed);
-  }
-  log('Control updated', { [name]: parsed });
-}
-
 function renderControls() {
   const container = document.querySelector('[data-control-panel]');
   if (!container) return;
 
-  const fragment = document.createDocumentFragment();
-  controlDefinitions.forEach((control) => {
-    const wrapper = document.createElement('label');
-    wrapper.className = 'slider';
-    wrapper.innerHTML = `
-      <div class="slider__header">
-        <span>${control.label}</span>
-        <span class="slider__value" data-display="${control.key}">${control.format(
-      state.settings[control.key],
-    )}</span>
-      </div>
-      <input
-        type="range"
-        name="${control.key}"
-        min="${control.min}"
-        max="${control.max}"
-        step="${control.step}"
-        value="${state.settings[control.key]}"
-        aria-label="${control.label}"
-      />
-    `;
-    const input = wrapper.querySelector('input');
-    input.addEventListener('input', handleControlChange);
-    fragment.appendChild(wrapper);
-  });
-
-  container.innerHTML = '';
-  container.appendChild(fragment);
-  log('Controls rendered');
+  container.textContent = 'Parameters evolve automatically—watch colors shift as separation (red), cohesion (green), and alignment (blue) adapt.';
+  log('Evolution notice rendered');
 }
 
 function start() {
@@ -255,6 +366,7 @@ function start() {
     }
     resizeCanvas();
     seedBoids();
+    seedFood();
     renderControls();
     ctx.fillStyle = 'rgba(10, 13, 18, 1)';
     ctx.fillRect(0, 0, canvas.clientWidth, canvas.clientHeight);


### PR DESCRIPTION
## Summary
- remove manual sliders and let boid steering traits evolve with mutation-based genomes
- colorize boids based on separation, cohesion, and alignment weights to visualize generational shifts
- refresh hero copy to note autonomous evolution while keeping food and hazard mechanics

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c2170fdd8832d8f0fb01daafda662)