### PR TITLE
Make reproduction individual and expand controls

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -147,7 +147,7 @@ main.layout {
   color: var(--muted);
 }
 
-.slider {
+.control {
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -157,7 +157,7 @@ main.layout {
   border-radius: 10px;
 }
 
-.slider__header {
+.control__header {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -165,15 +165,26 @@ main.layout {
   font-size: 14px;
 }
 
-.slider__value {
+.control__value {
   color: var(--accent);
   font-variant-numeric: tabular-nums;
   font-weight: 700;
 }
 
-.slider input[type='range'] {
+.control__input {
   width: 100%;
-  accent-color: var(--accent);
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  color: var(--text);
+  padding: 8px 10px;
+  font: inherit;
+}
+
+.control__input:focus {
+  outline: 2px solid rgba(110, 199, 255, 0.6);
+  border-color: rgba(110, 199, 255, 0.8);
+  box-shadow: 0 0 0 3px rgba(110, 199, 255, 0.15);
 }
 
 .canvas-panel {


### PR DESCRIPTION
## Summary
- ensure reproduction is driven by each boid’s own energy and food reserves instead of the top forager
- tighten reproduction checks with an energy reserve requirement and parent-proximate spawning only
- replace slider controls with numeric inputs and expose additional reproduction and energy tuning options
- refresh control styling to match the new input approach

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c8ebf867c832da65f18845fbee1d9)